### PR TITLE
Allow Article Schema on Pages and CPTs

### DIFF
--- a/extensions/free/articles/trunk/articles.php
+++ b/extensions/free/articles/trunk/articles.php
@@ -104,7 +104,7 @@ function _articles_init() {
 	if ( \is_admin() ) {
 		new Admin;
 		$loaded = true;
-	} elseif ( \the_seo_framework()->is_single() && 'post' === get_post_type() && 'organization' === \the_seo_framework()->get_option( 'knowledge_type' ) ) {
+	} elseif ( \the_seo_framework()->is_single() && 'organization' === \the_seo_framework()->get_option( 'knowledge_type' ) ) {
 		new Front;
 		$loaded = true;
 	}

--- a/extensions/free/articles/trunk/inc/classes/admin.class.php
+++ b/extensions/free/articles/trunk/inc/classes/admin.class.php
@@ -69,6 +69,7 @@ final class Admin extends Core {
 	 * @access private
 	 */
 	public function _prepare_inpost_views() {
+		global $current_screen;
 
 		//= Only output on Single/Post.
 		if ( ! isset( $current_screen->base ) || 'post' !== $current_screen->base )

--- a/extensions/free/articles/trunk/inc/classes/admin.class.php
+++ b/extensions/free/articles/trunk/inc/classes/admin.class.php
@@ -71,7 +71,7 @@ final class Admin extends Core {
 	public function _prepare_inpost_views() {
 
 		//= Only output on Single/Post.
-		if ( ! \the_seo_framework()->is_single_admin() )
+		if ( ! isset( $current_screen->base ) || 'post' !== $current_screen->base )
 			return;
 
 		\TSF_Extension_Manager\InpostGUI::activate_tab( 'structure' );


### PR DESCRIPTION
This allows article schema to be added to all pages and post types, not just blog posts.

It uses `$current_screen->base` instead of `$current_screen->post_type` to determine if the current screen is a single post edit/add screen.