### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
 		"source": "https://github.com/sybrew/The-SEO-Framework-Extension-Manager"
 	},
 	"require": {
-		"php": ">=5.2"
+		"php": "~5.5.21 || >=5.6.5"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+	"name": "sybrew/the-seo-framework-extension-manager",
+	"type": "wordpress-plugin",
+	"license": "GPLv3",
+	"description": "A WordPress.org plugin that allows you to manage extensions for The SEO Framework.",
+	"homepage": "https://theseoframework.com/extension-manager/",
+	"authors": [
+		{
+			"name": "Sybre Waaijer"
+		}
+	],
+	"keywords": ["wordpress", "seo"],
+	"support": {
+		"issues": "https://github.com/sybrew/The-SEO-Framework-Extension-Manager/issues/new/choose",
+		"source": "https://github.com/sybrew/The-SEO-Framework-Extension-Manager"
+	},
+	"require": {
+		"php": ">=5.2"
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,28 @@
 {
 	"name": "sybrew/the-seo-framework-extension-manager",
-	"type": "wordpress-plugin",
-	"license": "GPLv3",
 	"description": "A WordPress.org plugin that allows you to manage extensions for The SEO Framework.",
+	"keywords": [
+		"seo",
+		"wordpress", 
+		"plugin"
+	],
+	"type": "wordpress-plugin",
+	"license": "GPL-3.0-only",
 	"homepage": "https://theseoframework.com/extension-manager/",
 	"authors": [
 		{
-			"name": "Sybre Waaijer"
+			"name": "Sybre Waaijer",
+			"email": "sybre@theseoframework.com",
+			"homepage": "https://cyberwire.nl/",
+			"role": "Developer"
 		}
 	],
-	"keywords": ["wordpress", "seo"],
+	"require": {
+		"php": "~5.5.21 || >=5.6.5",
+		"composer/installers": "^1.0"
+	},
 	"support": {
 		"issues": "https://github.com/sybrew/The-SEO-Framework-Extension-Manager/issues/new/choose",
 		"source": "https://github.com/sybrew/The-SEO-Framework-Extension-Manager"
-	},
-	"require": {
-		"php": "~5.5.21 || >=5.6.5"
 	}
 }


### PR DESCRIPTION
Hey @sybrew , since you're removing the extension manager from the official WP plugin repo, can you add this `composer.json` file to the plugin and submit it to [Packagist](https://packagist.org/). I know a lot of people who rely on being able install the plugin with Composer via [WPackagist](https://wpackagist.org/). I added what I could find/what made sense to the file, ~(I think) all you need to add is [an email to the entry for you in `authors`](https://getcomposer.org/doc/04-schema.md#authors).~